### PR TITLE
Use unique user agent for request

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -15,9 +15,11 @@ require 'pry'
 # args = ['-h']
 # args = []
 
-args = {token: "e5b1c05c5cc0f6a90f621724ffe18258",
+args = {token: "0652400596ecf80e014176dd4bc17044",
  format: :json}
 
  a = Accern::Alpha.new(args)
 
-# c = Accern::Cli.new(args: args)
+# c = Accern::Cli.new(args)
+
+binding.pry

--- a/lib/accern/alpha.rb
+++ b/lib/accern/alpha.rb
@@ -52,7 +52,7 @@ module Accern
     private
 
     def header
-      { 'Authorization' => %(Token token="#{token}") }
+      { 'Authorization' => %(Token token="#{token}"),  'User-Agent' => "Accern #{VERSION} (#{RUBY_PLATFORM})" }
     end
 
     def save_last_id

--- a/lib/accern/version.rb
+++ b/lib/accern/version.rb
@@ -1,3 +1,3 @@
 module Accern
-  VERSION = '3.0.0'.freeze
+  VERSION = '3.0.1'.freeze
 end


### PR DESCRIPTION
When making the GET request change the user agent from "Ruby" to "Accern 3.0.0"