### PR TITLE
Add index filter to gem

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -12,12 +12,14 @@ require 'pry'
 # require "irb"
 # IRB.start(__FILE__)
 
-# args = ['-h']
-# args = []
 
 
-c = Accern::Cli.new(args: args)
+
+
+ticker = "amzn,aapl"
+# ["--ticker", "aapp,amaz,lol"]
+# token: '08b14780c4b4aae5ac97d92c33d25495',
+args = {format: :json, index: "sp500"}
+c = Accern::Cli.new( args: ["--index", "sp500,barrons400"])
 binding.pry
-
-
-# c = Accern::Cli.new(args)
+# ticker=amzn&

--- a/lib/accern/alpha.rb
+++ b/lib/accern/alpha.rb
@@ -1,11 +1,12 @@
 module Accern
   class Alpha
     attr_reader :token, :base_url, :uri, :last_id, :new_id, :docs,
-                :format, :flat, :params, :ticker
+                :format, :flat, :params, :ticker, :index
 
-    def initialize(token:, ticker:, format: :json, params: {})
+    def initialize(token:, ticker:, index:, format: :json)
       @token = token
       @ticker = ticker
+      @index = index
       @format = format
       @params = params
       @base_url = 'http://feed.accern.com/v3/alphas'
@@ -60,7 +61,7 @@ module Accern
       filters = Hash.new
       filters[:ticker] = ticker unless ticker.empty?
       filters[:last_id] = last_id if last_id
-      # filters[:index] = index if index
+      filters[:index] = index unless index.empty?
       filters
     end
 

--- a/lib/accern/cli.rb
+++ b/lib/accern/cli.rb
@@ -1,7 +1,8 @@
 module Accern
   class Cli
     attr_reader :stdout, :stdin, :token, :filetype, :valid_types, :config_path,
-                :options, :args, :feed, :tickers
+                :options, :args, :feed, :tickers,:indexes
+
 
     def initialize(stdout: $stdout, stdin: $stdin, args: [], feed: Alpha)
       @stdout = stdout
@@ -13,6 +14,7 @@ module Accern
       @config_path = "#{ENV['HOME']}/.accern.rc.yml"
       @feed = feed
       @tickers = []
+      @indexes = []
     end
 
     def start
@@ -22,7 +24,7 @@ module Accern
       if options[:init]
         ask_for_info
       else
-        feed.new(token: token, format: filetype.to_sym, ticker: tickers.join(','))
+        feed.new(token: token, format: filetype.to_sym, ticker: tickers.join(','), index: indexes.join(','))
             .download_loop(path: './feed.jsonl')
       end
     end
@@ -61,21 +63,42 @@ module Accern
         end
 
         opts.on("--ticker NAME", "Filters document by ticker") do |tic|
+
           options[:ticker] = tic.to_s.downcase.split(',')
           @tickers += options[:ticker]
         end
 
         opts.on("--ticker-file PATH", "Receives the path to a file that has tickers") do |t_path|
           options[:ticker_path] = t_path
-          @tickers += read_tickers(t_path)
+          @tickers += read_file(t_path)
         end
+
+        index_options = ['sp500', 'russell1000', 'russell3000', 'wilshire5000', 'barrons400']
+        opts.on("--index TYPE", "Filters document by index") do |i|
+          options[:index] = i.to_s.downcase.split(',')
+          options[:index] = sanitizes_input(options[:index])
+          raise OptionParser::InvalidArgument.new("Invalid index options") unless (options[:index] - index_options).empty?
+          @indexes += options[:index]
+        end
+
+        opts.on("--index-file PATH", "get filter indexes from file") do |i_path|
+          parsed = read_file(i_path)
+          parsed = sanitizes_input(parsed)
+          raise OptionParser::InvalidArgument.new("Invalid index options") unless (parsed - index_options).empty?
+          @indexes += parsed
+        end
+
       end
 
       parser.parse!(args)
-      @tickers.map {|t| t.gsub!(/\W/, '')}
+      @tickers = sanitizes_input(@tickers)
     end
 
     private
+
+    def sanitizes_input(arg)
+       arg.map {|t| t.gsub(/\W/, '')}
+    end
 
     def ask_for_info
       ask_for_token
@@ -106,9 +129,9 @@ module Accern
       stdout.puts 'Your client is now configured and settings saved to ~/.accern.rc.yml.'
     end
 
-    def read_tickers(path)
+    def read_file(path)
       return [] unless File.exist?(path)
-      File.readlines(options[:ticker_path]).map { |t| t.downcase.chomp }
+      File.readlines(path).map { |x| x.downcase.chomp }
     end
   end
 end

--- a/spec/accern/alpha_spec.rb
+++ b/spec/accern/alpha_spec.rb
@@ -4,20 +4,22 @@ module Accern
   RSpec.describe Alpha do
 
     it 'accepts query params' do
-      a = Alpha.new(token: 'xyz', ticker: 'aapl')
+      a = Alpha.new(token: 'xyz', ticker: 'aapl', index: 'wilshire5000')
       expect(a.ticker).to eq('aapl')
+      expect(a.index).to eq('wilshire5000')
     end
 
     it 'creates uri with correct query params' do
-      a = Alpha.new(token: 'xyz', ticker: "aapl,fb,amzn,goog")
+      a = Alpha.new(token: 'xyz', ticker: "aapl,fb,amzn,goog", index: "wilshire5000")
       a.create_uri
-      expect(a.uri.to_s).to include('ticker=aapl%2Cfb%2Camzn%2Cgoog')
+      expect(a.uri.to_s).to include('ticker=aapl%2Cfb%2Camzn%2Cgoog', 'index=wilshire5000')
     end
 
-    it 'creates correct uri when ticker is nil ' do
-      a = Alpha.new(token: 'xyz', ticker: "")
+    it 'creates correct uri when filters are nil ' do
+      a = Alpha.new(token: 'xyz', ticker: "", index: '')
       a.create_uri
-      expect(a.uri.to_s).not_to include('ticker')
+      expect(a.uri.to_s).not_to include('ticker', 'index')
+
     end
   end
 end


### PR DESCRIPTION
Add a --index flag that receives a argument ex: dow30

Should validate that index values must be the follow:
Supported Indexes
- sp500
- russell1000
- russell3000
- wilshire5000
- barrons400

Allow multiple indexes by passing in a comma separated list of indexes ex: --index "dow30, sp500"

Add a --index-file flag that receives the path to a file that has one index on each line.

When the program prints the URL that its hitting you should see the passed in indexes in the query string.